### PR TITLE
Made patcher only use libvirt api, and skip changes if guest is running.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,20 @@
 sudo: false
+
 language: python
 python:
 - '2.7'
 - '3.4'
 - '3.5'
 - '3.6'
+virtualenv:
+  system_site_packages: true
+
+addons:
+  apt:
+    packages:
+      - python-libvirt
+      - python3-libvirt
+
 install: pip install tox-travis
+
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,11 @@ python:
 - '3.4'
 - '3.5'
 - '3.6'
-virtualenv:
-  system_site_packages: true
 
 addons:
   apt:
     packages:
-      - python-libvirt
-      - python3-libvirt
+      - libvirt-dev
 
 install: pip install tox-travis
 

--- a/README.md
+++ b/README.md
@@ -19,12 +19,25 @@ Installation
 ### Arch Linux
 Install [virshpatcher](https://aur.archlinux.org/packages/virshpatcher/) from the AUR.
 
-### Others
-Use `pip`:
+
+### Debian / Ubuntu
 
 ```
-$ pip install -U https://github.com/PassthroughPOST/virsh-patcher/archive/master.zip
+sudo apt-get install python-libvirt
+sudo pip install -U https://github.com/PassthroughPOST/virsh-patcher/archive/master.zip
 ```
+
+### Fedora
+
+```
+$ sudo dnf install libvirt-python
+$ sudo pip install -U https://github.com/PassthroughPOST/virsh-patcher/archive/master.zip
+```
+
+### Other Distributions
+
+The `libvirt-python` package is a dependency. This can be either installed by you distributions
+package manager, or via pip. In the latter case, `libvirt-dev` is required.
 
 
 Usage

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 Virsh Patcher ![](https://travis-ci.org/PassthroughPOST/virsh-patcher.svg?branch=master)
 ===================
 
-Simple utility to apply common changes to libvirtd domain xml files.
+Simple utility to apply common changes to libvirtd guests.
 
-Can either edit the xml file directly, or apply the patch via a hack around `virsh edit`.
+Changes will not be applied if the guest is running.
 
 
 Supported Fixes
@@ -36,16 +36,19 @@ $ virshpatcher --error43 --hugepages --host-passthrough win10-guest
 
 ```
 $ virshpatcher --help
-usage: virshpatcher [--error43] [--hugepages] [--host-passthrough]
-                    [--patch PATCH] [--help]
-                    [FILE]
+usage: virshpatcher [--connect URI] [--error43] [--hugepages]
+                    [--host-passthrough] [--patch PATCH] [--help]
+                    [--vendor-id ab1234567890] [--random-vendor-id]
+                    [DOMAIN [DOMAIN ...]]
 
 libvirtd xml patcher
 
 positional arguments:
-  FILE                  XML file to edit, or libvirtd domain.
+  DOMAIN
 
 optional arguments:
+  --connect URI, -c URI
+                        hypervisor connection URI
   --error43             Add fixes for 'error43' with nvidia devices.
   --hugepages           Make guest use hugepages.
   --host-passthrough    Make guest CPU model `host_passthrough`.
@@ -61,7 +64,6 @@ optional arguments:
 Future Improvements
 -----------------------
 
- * Use libvirt API instead of `virsh edit` hack.
  * Add ability to connect PCI devices to guest (By name/pattern/id?)
  * Interactive (?)
  * More tests.

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     setup_requires=['pytest-runner'],
     tests_require=['pytest'],
     classifiers=[],
-    install_requires=[],
+    install_requires=['libvirt-python'],
     entry_points={
         'console_scripts': [
             'virshpatcher=virshpatcher.main:main',

--- a/tox.ini
+++ b/tox.ini
@@ -4,4 +4,5 @@ envlist = py27,py34,py35,py36
 [testenv]
 deps=
   pytest
+  libvirt-python
 commands=py.test

--- a/virshpatcher/patcher.py
+++ b/virshpatcher/patcher.py
@@ -12,7 +12,7 @@ class XMLPatcher(object):
 
     def patch(self, tree, args):
         for patch_set in self.nodes:
-            node = tree.getroot()
+            node = tree
 
             for tag in patch_set:
                 creator = getattr(
@@ -28,6 +28,8 @@ class XMLPatcher(object):
                 new = node.find(tag)
 
                 if new is None:
+                    if isinstance(node, ET.ElementTree):
+                        node = node.getroot()
                     new = ET.SubElement(node, *creator(args))
 
                 patcher(args, new)


### PR DESCRIPTION
 * Removed ability to edit XML files directly.
   If you're doing this, you should know what you're doing, and can probably edit the XML by hand.
* Added a dependency for libvirt
* Removed the `virsh edit` hack and made changes through libvirt api.